### PR TITLE
pass throught rest parameters to fetch call

### DIFF
--- a/.changeset/slow-foxes-promise.md
+++ b/.changeset/slow-foxes-promise.md
@@ -1,0 +1,5 @@
+---
+'@ssrx/vite': patch
+---
+
+pass through all rest parameters to the fetch function. those are needed for tracing purposes

--- a/packages/vite/src/plugins/dev-server.ts
+++ b/packages/vite/src/plugins/dev-server.ts
@@ -41,7 +41,7 @@ export type DevServerOptions = {
   config: Config;
 };
 
-type Fetch = (request: Request) => Promise<Response>;
+type Fetch = (request: Request, ...args: unknown[]) => Promise<Response>;
 
 function createMiddleware(server: ViteDevServer, options: DevServerOptions): Promise<Connect.HandleFunction> {
   // @ts-expect-error ignore
@@ -74,8 +74,8 @@ function createMiddleware(server: ViteDevServer, options: DevServerOptions): Pro
     }
 
     void getRequestListener(
-      async (request: Request) => {
-        const response = await app!.fetch(request);
+      async (request: Request, ...args) => {
+        const response = await app!.fetch(request, ...args);
 
         // Allow the server to pass rendering errors through in development
         // we pass these through to vite to display in the error overlay


### PR DESCRIPTION
This will ensure runtime bindings and possibly additional parameters
which may be passed by hono are also forwarded to the server implementation.

this is crucial in order to implement request tracing by using pino or winston
for example if somebody (me) want to use elastic apm tracing

Thanks