### PR TITLE
fix(example): handle redirects in TanStack router

### DIFF
--- a/examples/tanstack-router-simple/src/routes/redirect.tsx
+++ b/examples/tanstack-router-simple/src/routes/redirect.tsx
@@ -26,12 +26,16 @@ function RedirectComponent() {
         well on first load when relevant.
       </p>
 
-      <p>NOTE: the server side of things doesn't seem to be working atm. Could be an issue in tanstack router.</p>
+      <p>
+        <Link to="/redirect" search={{ doRedirect: true }} className="text-blue-700">
+          Client Side Redirect
+        </Link>
+      </p>
 
       <p>
-        <Link to="/redirect" search={{ doRedirect: true }}>
-          Redirect
-        </Link>
+        <a href="/redirect?doRedirect=true" className="text-blue-700">
+          Server Side Redirect
+        </a>
       </p>
     </div>
   );

--- a/examples/tanstack-router-simple/src/server.ts
+++ b/examples/tanstack-router-simple/src/server.ts
@@ -17,6 +17,11 @@ const server = new Hono()
     try {
       const { app, router } = await entry.render(c.req.raw);
 
+      // Handle redirects
+      if (router.state.redirect && router.state.redirect?.to) {
+        return c.redirect(router.state.redirect?.to);
+      }
+
       const { stream, statusCode } = await renderToStream({
         app: () => app,
         req: c.req.raw,
@@ -39,7 +44,7 @@ const server = new Hono()
 
       let status = statusCode();
 
-      // Handle redirects
+      // Handle 404 errors
       if (router.hasNotFoundMatch() && status !== 500) status = 404;
 
       return new Response(stream, { status, headers: { 'Content-Type': 'text/html' } });

--- a/examples/tanstack-router-simple/src/server.ts
+++ b/examples/tanstack-router-simple/src/server.ts
@@ -18,8 +18,8 @@ const server = new Hono()
       const { app, router } = await entry.render(c.req.raw);
 
       // Handle redirects
-      if (router.state.redirect && router.state.redirect?.to) {
-        return c.redirect(router.state.redirect?.to);
+      if (router.state.redirect) {
+        return c.redirect(router.state.redirect.href);
       }
 
       const { stream, statusCode } = await renderToStream({


### PR DESCRIPTION
This PR fixes the doRedirect=true example in the `examples/tanstack-router-simple` folder, as well as just being a general fix for anyone trying to use redirects in Tanstack Router. 